### PR TITLE
Fix #23: Code Duplication in ScoreSnapshot.java::hashCode Detected by PMD CPD

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/battle/snapshot/ScoreSnapshot.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/snapshot/ScoreSnapshot.java
@@ -14,6 +14,7 @@ import robocode.control.snapshot.IScoreSnapshot;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Objects;
 
 
 /**
@@ -433,46 +434,28 @@ public final class ScoreSnapshot implements Serializable, IXmlSerializable, ISco
 			}
 		});
 	}
-
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		long temp;
-
-		temp = Double.doubleToLongBits(currentBulletDamageScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(currentBulletKillBonus);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(currentRammingDamageScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(currentRammingKillBonus);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(currentScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(currentSurvivalBonus);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(currentSurvivalScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		temp = Double.doubleToLongBits(totalBulletDamageScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(totalBulletKillBonus);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		result = prime * result + totalFirsts;
-		temp = Double.doubleToLongBits(totalLastSurvivorBonus);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(totalRammingDamageScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(totalRammingKillBonus);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(totalScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		result = prime * result + totalSeconds;
-		temp = Double.doubleToLongBits(totalSurvivalScore);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		result = prime * result + totalThirds;
-		return result;
+		return Objects.hash(
+				currentBulletDamageScore,
+				currentBulletKillBonus,
+				currentRammingDamageScore,
+				currentRammingKillBonus,
+				currentScore,
+				currentSurvivalBonus,
+				currentSurvivalScore,
+				name,
+				totalBulletDamageScore,
+				totalBulletKillBonus,
+				totalFirsts,
+				totalLastSurvivorBonus,
+				totalRammingDamageScore,
+				totalRammingKillBonus,
+				totalScore,
+				totalSeconds,
+				totalSurvivalScore,
+				totalThirds
+		);
 	}
 
 	@Override


### PR DESCRIPTION
## Description
This pull request addresses code duplication in the `hashCode` method of `ScoreSnapshot.java`, as identified by PMD CPD. The duplication consisted of repeated operations on individual fields, resulting in redundant code for generating hash values.

## Changes Made
- Refactored the `hashCode` method to use `Objects.hash()`, simplifying the code and improving readability and maintainability.
- Removed repetitive `Double.doubleToLongBits` calculations for each field, consolidating them into a single, concise `Objects.hash()` call.

## Impact
This change eliminates the identified code duplication, making the `hashCode` implementation cleaner and reducing the potential for future maintenance issues.
