### PR TITLE
Fix #37: Code Duplication in Battle.java (lines 665 & 686)

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -659,17 +659,9 @@ public final class Battle extends BaseBattle {
 	private void wakeupSerial(List<RobotPeer> robotsAtRandom) {
 		for (RobotPeer robotPeer : robotsAtRandom) {
 			if (robotPeer.isRunning()) {
-				// This call blocks until the robot's thread actually wakes up.
 				robotPeer.waitWakeup();
-
 				if (robotPeer.isAlive()) {
-					if (isDebugging() || robotPeer.isPaintEnabled()) {
-						robotPeer.waitSleeping(DEBUG_TURN_WAIT_MILLIS, 1);
-					} else if (currentTime == 1) {
-						robotPeer.waitSleeping(millisWait * 10, 1);
-					} else {
-						robotPeer.waitSleeping(millisWait, nanoWait);
-					}
+					applyWaitSleeping(robotPeer);
 				}
 			}
 		}
@@ -678,20 +670,23 @@ public final class Battle extends BaseBattle {
 	private void wakeupParallel(List<RobotPeer> robotsAtRandom) {
 		for (RobotPeer robotPeer : robotsAtRandom) {
 			if (robotPeer.isRunning()) {
-				// This call blocks until the robot's thread actually wakes up.
 				robotPeer.waitWakeup();
 			}
 		}
 		for (RobotPeer robotPeer : robotsAtRandom) {
 			if (robotPeer.isRunning() && robotPeer.isAlive()) {
-				if (isDebugging() || robotPeer.isPaintEnabled()) {
-					robotPeer.waitSleeping(DEBUG_TURN_WAIT_MILLIS, 1);
-				} else if (currentTime == 1) {
-					robotPeer.waitSleeping(millisWait * 10, 1);
-				} else {
-					robotPeer.waitSleeping(millisWait, nanoWait);
-				}
+				applyWaitSleeping(robotPeer);
 			}
+		}
+	}
+
+	private void applyWaitSleeping(RobotPeer robotPeer) {
+		if (isDebugging() || robotPeer.isPaintEnabled()) {
+			robotPeer.waitSleeping(DEBUG_TURN_WAIT_MILLIS, 1);
+		} else if (currentTime == 1) {
+			robotPeer.waitSleeping(millisWait * 10, 1);
+		} else {
+			robotPeer.waitSleeping(millisWait, nanoWait);
 		}
 	}
 


### PR DESCRIPTION
## Refactoring One
By abstracting the waitSleeping logic into a separate applyWaitSleepingLogic method, we simplify the code structure, reduce potential errors, and ensure any future changes to the waitSleeping criteria need to be updated in only one place. This approach preserves the distinct handling of wakeupSerial and wakeupParallel while eliminating redundancy, which ultimately makes the code easier to read and maintain.
## Refactoring Two (reverted)
1. Define `turnAmount `variable: Instead of recalculating turnAmount in each branch, i changed the calculation based on the BodyTurnRemaining value.
2. Extract adjustHeadings() Method: Moved the update logic for` bodyHeading`,` gunHeading`, and `radarHeading` into the extracted method. This method also adjusts GunTurnRemaining and RadarTurnRemaining based on flags.

## Result
1. **For Refactoring One:** Extracting ` applyWaitSleeping()` for the duplicated waitSleeping logic, which enhances code readability and maintainability. And by isolating the waitSleeping logic into a separate method (`applyWaitSleeping()`), redundancy is reduced and make future modifications more efficient.
2. **For Refactoring Two**: By extracting the common parts of the heading adjustments into a function, redundant code blocks will be removed. This will clean up the updateHeading method significantly, keeping it shorter and easier to read. With this refactoring, updates to the heading adjustments will only need to happen in one place, reducing the risk of inconsistencies.